### PR TITLE
fixes loading of the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A simple bash script to print the current track you're playing on spotify in a s
   - change the token
   - change the channel
   - *optional* change the color
-  - *bonus* set a footer icon url in the JSON part
+  - *bonus* set a footer icon url
 4. execute the script, if nothing happens remove the `> /dev/null` redirect to see the error
 
 I created an Alfred workflow to quickly execute the script.

--- a/slackspotify.sh
+++ b/slackspotify.sh
@@ -12,14 +12,16 @@ CONFIGFILE="slackspotify.cfg"
 
 # check if the config file exists
 
-if [[ ! -f "$CONFIGFILE" ]]; then
+LOCALDIR=`dirname $0`
+
+if [[ ! -f "$LOCALDIR/$CONFIGFILE" ]]; then
         echo "config file $CONFIGFILE could not be found"
         exit 1
 fi
 
 # load the config
 
-. "$CONFIGFILE"
+. "$LOCALDIR/$CONFIGFILE"
 
 # gather all data from spotify
 ARTIST=$(osascript -e 'tell application "Spotify" to artist of current track')


### PR DESCRIPTION
When the script was invoked from a different location than the directory the script is in the config file wouldn't be loaded.

This is fixed now